### PR TITLE
feat: Create static HTML version of DataStack component

### DIFF
--- a/data_stack.html
+++ b/data_stack.html
@@ -1,0 +1,407 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Next-Gen Data Stack</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        /* Additional styles if needed, though Tailwind should cover most */
+        .icon-placeholder {
+            width: 24px;
+            height: 24px;
+            display: inline-block;
+            background-color: #ccc; /* Placeholder color */
+            border-radius: 4px;
+            text-align: center;
+            line-height: 24px;
+            font-size: 10px;
+            color: #fff;
+        }
+    </style>
+</head>
+<body class="min-h-screen bg-white">
+
+    <!-- Hero Section -->
+    <section class="bg-gradient-to-br from-blue-50 via-white to-purple-50 py-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-16">
+                <h1 class="text-4xl lg:text-5xl font-bold text-gray-900 mb-6">
+                    Next-Gen
+                    <span class="bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+                        Data Stack
+                    </span>
+                </h1>
+                <p class="text-xl text-gray-600 max-w-4xl mx-auto leading-relaxed">
+                    Build your enterprise data foundation with our comprehensive stack. From data ingestion to analytics,
+                    we provide the infrastructure your AI agents need to make intelligent decisions.
+                </p>
+            </div>
+        </div>
+    </section>
+
+    <!-- Data Stack Components Section -->
+    <section class="py-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-16">
+                <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
+                    Complete Data Infrastructure
+                </h2>
+                <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    Every component optimized for AI and machine learning workloads
+                </p>
+            </div>
+
+            <div class="grid md:grid-cols-2 gap-8 mb-16">
+                <!-- Fivetran Partnership Card -->
+                <div class="border-none shadow-lg hover:shadow-xl transition-shadow duration-300 rounded-lg">
+                    <div class="p-6">
+                        <div class="flex items-center space-x-4 mb-4">
+                            <div class="w-12 h-12 bg-gradient-to-r from-blue-600 to-cyan-600 rounded-lg flex items-center justify-center">
+                                <!-- Database Icon Placeholder -->
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-white"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg>
+                            </div>
+                            <div>
+                                <h3 class="text-xl font-semibold text-gray-900">Fivetran Partnership</h3>
+                                <p class="text-sm font-medium text-blue-600">Official Data Integration Partner</p>
+                            </div>
+                        </div>
+                        <div>
+                            <p class="text-gray-600 mb-4">Complete data foundation architecture and roadmap with platform-agnostic deployment</p>
+                            <ul class="space-y-2">
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    500+ pre-built connectors
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Real-time data synchronization
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Automated schema drift handling
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Enterprise-grade security & compliance
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Google Cloud Services Card -->
+                <div class="border-none shadow-lg hover:shadow-xl transition-shadow duration-300 rounded-lg">
+                    <div class="p-6">
+                        <div class="flex items-center space-x-4 mb-4">
+                            <div class="w-12 h-12 bg-gradient-to-r from-green-600 to-teal-600 rounded-lg flex items-center justify-center">
+                                <!-- Cloud Icon Placeholder -->
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-white"><path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"></path></svg>
+                            </div>
+                            <div>
+                                <h3 class="text-xl font-semibold text-gray-900">Google Cloud Services</h3>
+                                <p class="text-sm font-medium text-blue-600">Verified Cloud Partner</p>
+                            </div>
+                        </div>
+                        <div>
+                            <p class="text-gray-600 mb-4">Advanced analytics and AI infrastructure on Google Cloud Platform</p>
+                            <ul class="space-y-2">
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    BigQuery data warehousing
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Vertex AI model deployment
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Cloud SQL database solutions
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Multi-region data replication
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Looker Analytics Card -->
+                <div class="border-none shadow-lg hover:shadow-xl transition-shadow duration-300 rounded-lg">
+                    <div class="p-6">
+                        <div class="flex items-center space-x-4 mb-4">
+                            <div class="w-12 h-12 bg-gradient-to-r from-purple-600 to-pink-600 rounded-lg flex items-center justify-center">
+                                <!-- BarChart3 Icon Placeholder -->
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-white"><line x1="12" y1="20" x2="12" y2="10"></line><line x1="18" y1="20" x2="18" y2="4"></line><line x1="6" y1="20" x2="6" y2="16"></line></svg>
+                            </div>
+                            <div>
+                                <h3 class="text-xl font-semibold text-gray-900">Looker Analytics</h3>
+                                <p class="text-sm font-medium text-blue-600">Business Intelligence & Visualization</p>
+                            </div>
+                        </div>
+                        <div>
+                            <p class="text-gray-600 mb-4">Self-service analytics platform for data-driven decision making</p>
+                            <ul class="space-y-2">
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Interactive dashboards
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Embedded analytics
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Real-time reporting
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Custom data modeling
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Systems Integration Card -->
+                <div class="border-none shadow-lg hover:shadow-xl transition-shadow duration-300 rounded-lg">
+                    <div class="p-6">
+                        <div class="flex items-center space-x-4 mb-4">
+                            <div class="w-12 h-12 bg-gradient-to-r from-orange-600 to-red-600 rounded-lg flex items-center justify-center">
+                                <!-- Zap Icon Placeholder -->
+                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-white"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>
+                            </div>
+                            <div>
+                                <h3 class="text-xl font-semibold text-gray-900">Systems Integration</h3>
+                                <p class="text-sm font-medium text-blue-600">Enterprise System Connectivity</p>
+                            </div>
+                        </div>
+                        <div>
+                            <p class="text-gray-600 mb-4">Deep SAP modeling and logic integration for enterprise workflows</p>
+                            <ul class="space-y-2">
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    SAP HANA connectivity
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Real-time ERP data sync
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Custom BAPI development
+                                </li>
+                                <li class="flex items-center text-sm text-gray-600">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-4 h-4 text-green-500 mr-2 flex-shrink-0"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+                                    Legacy system modernization
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Architecture Features Section -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-16">
+                <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
+                    Modern Data Architecture
+                </h2>
+                <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    Built for scale, security, and real-time performance
+                </p>
+            </div>
+
+            <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <!-- Unified Data Platform Card -->
+                <div class="border-none shadow-lg text-center rounded-lg">
+                    <div class="p-6">
+                        <div class="w-12 h-12 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
+                            <!-- Layers Icon Placeholder -->
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-white"><polygon points="12 2 2 7 12 12 22 7 12 2"></polygon><polyline points="2 17 12 22 22 17"></polyline><polyline points="2 12 12 17 22 12"></polyline></svg>
+                        </div>
+                        <h3 class="text-lg font-semibold text-gray-900 mb-2">Unified Data Platform</h3>
+                        <p class="text-gray-600 text-sm">Single source of truth for all enterprise data</p>
+                    </div>
+                </div>
+
+                <!-- Real-time Connectors Card -->
+                <div class="border-none shadow-lg text-center rounded-lg">
+                    <div class="p-6">
+                        <div class="w-12 h-12 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
+                            <!-- Cable Icon Placeholder -->
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-white">
+                                <path d="M4 10c0-2.21 1.79-4 4-4h1.5c.83 0 1.5.67 1.5 1.5S10.33 9 9.5 9H8c-2.21 0-4 1.79-4 4s1.79 4 4 4h1.5c.83 0 1.5.67 1.5 1.5S10.33 20 9.5 20H8c-2.21 0-4-1.79-4-4Z"/>
+                                <path d="M20 14c0 2.21-1.79 4-4 4h-1.5c-.83 0-1.5-.67-1.5-1.5S13.67 15 14.5 15H16c2.21 0 4-1.79 4-4s-1.79-4-4-4h-1.5c-.83 0-1.5-.67-1.5-1.5S13.67 4 14.5 4H16c2.21 0 4 1.79 4 4Z"/>
+                                <path d="M8 12h8"/>
+                            </svg>
+                        </div>
+                        <h3 class="text-lg font-semibold text-gray-900 mb-2">Real-time Connectors</h3>
+                        <p class="text-gray-600 text-sm">Live data streaming from any source system</p>
+                    </div>
+                </div>
+
+                <!-- Enterprise Security Card -->
+                <div class="border-none shadow-lg text-center rounded-lg">
+                    <div class="p-6">
+                        <div class="w-12 h-12 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
+                            <!-- Shield Icon Placeholder -->
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-white"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path></svg>
+                        </div>
+                        <h3 class="text-lg font-semibold text-gray-900 mb-2">Enterprise Security</h3>
+                        <p class="text-gray-600 text-sm">Bank-level encryption and compliance standards</p>
+                    </div>
+                </div>
+
+                <!-- Multi-Cloud Ready Card -->
+                <div class="border-none shadow-lg text-center rounded-lg">
+                    <div class="p-6">
+                        <div class="w-12 h-12 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
+                            <!-- Globe Icon Placeholder -->
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-6 h-6 text-white"><circle cx="12" cy="12" r="10"></circle><line x1="2" y1="12" x2="22" y2="12"></line><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path></svg>
+                        </div>
+                        <h3 class="text-lg font-semibold text-gray-900 mb-2">Multi-Cloud Ready</h3>
+                        <p class="text-gray-600 text-sm">Deploy across AWS, GCP, Azure, or hybrid environments</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Benefits Section -->
+    <section class="py-20">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-16">
+                <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
+                    Measurable Impact
+                </h2>
+                <p class="text-xl text-gray-600">
+                    Real results from our data stack implementations
+                </p>
+            </div>
+
+            <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+                <!-- Benefit 1 -->
+                <div class="text-center">
+                    <div class="w-16 h-16 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <!-- TrendingUp Icon Placeholder -->
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-8 h-8 text-white"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg>
+                    </div>
+                    <h3 class="text-3xl font-bold text-gray-900 mb-2">10x</h3>
+                    <p class="text-gray-600">Faster time to insights</p>
+                </div>
+                <!-- Benefit 2 -->
+                <div class="text-center">
+                    <div class="w-16 h-16 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <!-- TrendingUp Icon Placeholder -->
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-8 h-8 text-white"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg>
+                    </div>
+                    <h3 class="text-3xl font-bold text-gray-900 mb-2">90%</h3>
+                    <p class="text-gray-600">Reduction in data preparation time</p>
+                </div>
+                <!-- Benefit 3 -->
+                <div class="text-center">
+                    <div class="w-16 h-16 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <!-- TrendingUp Icon Placeholder -->
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-8 h-8 text-white"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg>
+                    </div>
+                    <h3 class="text-3xl font-bold text-gray-900 mb-2">99.9%</h3>
+                    <p class="text-gray-600">Data pipeline uptime guarantee</p>
+                </div>
+                <!-- Benefit 4 -->
+                <div class="text-center">
+                    <div class="w-16 h-16 bg-gradient-to-r from-blue-600 to-purple-600 rounded-full flex items-center justify-center mx-auto mb-4">
+                        <!-- TrendingUp Icon Placeholder -->
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-8 h-8 text-white"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"></polyline><polyline points="17 6 23 6 23 12"></polyline></svg>
+                    </div>
+                    <h3 class="text-3xl font-bold text-gray-900 mb-2">50+</h3>
+                    <p class="text-gray-600">Data sources integrated seamlessly</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Implementation Process Section -->
+    <section class="py-20 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-16">
+                <h2 class="text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
+                    Implementation Process
+                </h2>
+                <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+                    From assessment to deployment, we handle every step
+                </p>
+            </div>
+
+            <div class="grid md:grid-cols-3 gap-8">
+                <!-- Phase 1 Card -->
+                <div class="border-none shadow-lg rounded-lg">
+                    <div class="p-6">
+                        <span class="inline-block bg-blue-100 text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded w-fit mb-4">Phase 1</span>
+                        <h3 class="text-xl font-semibold text-gray-900 mb-2">Assessment & Architecture</h3>
+                        <ul class="space-y-2 text-gray-600">
+                            <li>• Current state analysis</li>
+                            <li>• Data source identification</li>
+                            <li>• Architecture design</li>
+                            <li>• Migration planning</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <!-- Phase 2 Card -->
+                <div class="border-none shadow-lg rounded-lg">
+                     <div class="p-6">
+                        <span class="inline-block bg-blue-100 text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded w-fit mb-4">Phase 2</span>
+                        <h3 class="text-xl font-semibold text-gray-900 mb-2">Implementation & Integration</h3>
+                        <ul class="space-y-2 text-gray-600">
+                            <li>• Connector deployment</li>
+                            <li>• Data pipeline setup</li>
+                            <li>• Quality monitoring</li>
+                            <li>• Performance optimization</li>
+                        </ul>
+                    </div>
+                </div>
+
+                <!-- Phase 3 Card -->
+                <div class="border-none shadow-lg rounded-lg">
+                    <div class="p-6">
+                        <span class="inline-block bg-blue-100 text-blue-800 text-xs font-semibold mr-2 px-2.5 py-0.5 rounded w-fit mb-4">Phase 3</span>
+                        <h3 class="text-xl font-semibold text-gray-900 mb-2">Analytics & Optimization</h3>
+                        <ul class="space-y-2 text-gray-600">
+                            <li>• Dashboard creation</li>
+                            <li>• Model deployment</li>
+                            <li>• User training</li>
+                            <li>• Ongoing support</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- CTA Section -->
+    <section class="py-20 bg-gradient-to-r from-blue-600 to-purple-600">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h2 class="text-3xl lg:text-4xl font-bold text-white mb-4">
+                Ready to Build Your Data Foundation?
+            </h2>
+            <p class="text-xl text-blue-100 mb-8 max-w-3xl mx-auto">
+                Let's architect a data stack that powers your AI transformation.
+                Start with a comprehensive assessment of your current infrastructure.
+            </p>
+            <div class="flex justify-center">
+                <a href="/contact" class="bg-white text-blue-600 hover:bg-gray-100 px-8 py-3 text-lg font-semibold rounded-md shadow-md hover:shadow-lg transition-shadow duration-300 flex items-center">
+                    Schedule Data Assessment
+                    <!-- ArrowRight Icon Placeholder -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="ml-2 w-5 h-5"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
+                </a>
+            </div>
+        </div>
+    </section>
+
+</body>
+</html>


### PR DESCRIPTION
Converts the DataStack React component into a single data_stack.html file. Includes Tailwind CSS via CDN and uses inline SVGs for icons. All sections and dynamic data from the original component are represented statically in the HTML.